### PR TITLE
Add missing authentication to experimental API endpoint.

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -389,6 +389,7 @@ def delete_pool(name):
 
 
 @api_experimental.route('/lineage/<string:dag_id>/<string:execution_date>', methods=['GET'])
+@requires_authentication
 def get_lineage(dag_id: str, execution_date: str):
     """Get Lineage details for a DagRun"""
     # Convert string datetime into actual datetime


### PR DESCRIPTION
I couldn't find a good reason why this endpoint was missing the authentication decorator. This would likely break any clients calling this endpoint in an unauthenticated manner, but given it's not documented that it should be unauthenticated, I would imagine this is fine.

This might deserve a low-impact CVE. It looks like it went wrong in fbd994a4cff32be42474c5a121ec6fb888d05cd8, during a refactor of the stable API which seems unrelated to this endpoint.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
